### PR TITLE
Set up development environment for NetDiagPeer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+`NetDiagPeer` is a single-machine/peer-to-peer network diagnostics tool written in pure
+Python (standard library only, no pip dependencies, Python 3.8+). Key entry points are
+documented in `README.md`:
+- `main.py` / `network_diagnostic.py` — CLI entry point (`netdiag_core.main`)
+- `gui_main.py` — Tkinter GUI entry point (`netdiag_gui.launch_gui`)
+- `netdiag_core.py` — diagnostic engine; `netdiag_gui.py` — Tkinter UI
+
+### Running
+Standard run commands are in `README.md` (e.g. `python3 main.py --session <name>`,
+`python3 gui_main.py`). Non-obvious caveats for this environment:
+- The GUI (`gui_main.py` / `python3 main.py --gui`) requires the `python3-tk` system
+  package (Tkinter). It is not installed by `pip`; it is installed once during VM setup and
+  persists in the snapshot. If `import tkinter` fails, reinstall with
+  `sudo apt-get install -y python3-tk`.
+- Quick end-to-end smoke test without a second machine: point the tool at itself with
+  `python3 main.py --peer 127.0.0.1 --session test --startup-delay 0.5 --discovery-timeout 1 --linger 0`.
+  A healthy run prints `Direct HTTP: OK` and `Reverse callback: OK`.
+- Two local peers can be tested by running two instances that share the same `--session`
+  and `--discovery-port` but use different `--port` values; they find each other over UDP
+  broadcast on the container's network.
+- Console/report text is intentionally in Russian — this is expected, not a bug.
+
+### Lint / test / build
+- There is no automated test suite and no linter config in the repo. Use
+  `python3 -m py_compile *.py` as the syntax/sanity check.
+- `build_windows.bat` builds a Windows `.exe` via PyInstaller and only runs on Windows; it
+  is not used for development on this Linux environment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and verifies the development environment for `NetDiagPeer`, a pure-Python (stdlib-only) network diagnostics tool. No pip dependencies exist; the only non-stdlib requirement is the `python3-tk` system package for the Tkinter GUI.

- Added `AGENTS.md` with `## Cursor Cloud specific instructions` covering how to run the CLI/GUI, the `python3-tk` requirement, a self-loopback smoke test, two-peer discovery, and the syntax-check command.
- Update script set to `python3 --version` (project has zero pip dependencies; `python3-tk` is installed once during VM setup and persists in the snapshot).

## Verification
- CLI self-loopback diagnostics: `Direct HTTP: OK`, `Reverse callback: OK`.
- Two-peer UDP broadcast discovery between two local instances.
- JSON output + `--save-report`.
- GUI launches via `python3 gui_main.py` and runs diagnostics successfully.
- `python3 -m py_compile *.py` passes for all modules.

### GUI demo
[netdiag_gui_diagnostics_demo.mp4](https://cursor.com/agents/bc-88f6d263-e32d-4bdf-ab2a-17fdc0ff37e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnetdiag_gui_diagnostics_demo.mp4)
[NetDiagPeer GUI diagnostics report](https://cursor.com/agents/bc-88f6d263-e32d-4bdf-ab2a-17fdc0ff37e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnetdiag_gui_report.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88f6d263-e32d-4bdf-ab2a-17fdc0ff37e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88f6d263-e32d-4bdf-ab2a-17fdc0ff37e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

